### PR TITLE
Fix: Env-mediate expressions in run blocks

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -116,9 +116,12 @@ jobs:
       # Log brief test results
       - name: 'Test results summary'
         if: always()
+        env:
+          CONTENT_TEST_OUTCOME: ${{ steps.content_test.outcome }}
+          HEALTH_TEST_OUTCOME: ${{ steps.health_test.outcome }}
         run: |
-          echo "Content Test: ${{ steps.content_test.outcome }}"
-          echo "Health Test: ${{ steps.health_test.outcome }}"
+          echo "Content Test: ${CONTENT_TEST_OUTCOME}"
+          echo "Health Test: ${HEALTH_TEST_OUTCOME}"
 
       # Stop container
       - name: 'Stop and remove container'


### PR DESCRIPTION
## Summary

`zizmor --persona auditor` reported **2 `template-injection` findings** in `.github/workflows/testing.yaml`. This clears both — the repository now reports **no findings**.

## Why this is now urgent

The organisation lowered the zizmor floor to `informational` and made the gate block on *any* finding ([`.github`#133](https://github.com/lfreleng-actions/.github/pull/133)). These findings were always present but invisible; they now fail **every** pull request in this repository.

**Three Dependabot updates are held up behind this**, all failing solely on `Audit Workflows`:

| PR | Update |
| -- | ------ |
| #141 | `actions/checkout` 7.0.0 → 7.0.1 |
| #140 | `release-drafter/release-drafter` |
| #139 | `lfit/releng-reusable-workflows` |

## The issue

GitHub expressions were expanded directly inside a `run:` block. Expansion happens *before* the shell sees the script, so the expanded value becomes part of the program text rather than data — a crafted value can inject commands.

```diff
   - name: 'Test results summary'
     if: always()
+    env:
+      CONTENT_TEST_OUTCOME: ${{ steps.content_test.outcome }}
+      HEALTH_TEST_OUTCOME: ${{ steps.health_test.outcome }}
     run: |
-      echo "Content Test: ${{ steps.content_test.outcome }}"
-      echo "Health Test: ${{ steps.health_test.outcome }}"
+      echo "Content Test: ${CONTENT_TEST_OUTCOME}"
+      echo "Health Test: ${HEALTH_TEST_OUTCOME}"
```

**One step changed, 2 expressions env-mediated.**

## No behavioural change — and that is verified, not asserted

The same values reach the same commands; only the transport changes (expression → environment variable → shell variable).

This was checked mechanically rather than by eye. For the rewritten step, each `env:` expression was substituted back into the new script and the result compared to the original:

```
steps compared      : 12
steps rewritten     : 1
round-trip verified : 1
RESULT: transformation is provably transport-only
```

## Validation

- `zizmor --persona auditor --min-severity informational .` — **2 findings → 0**
- `pre-commit run --files …` — all hooks pass, including **actionlint**, workflow schema validation, timeout-minutes check, yamllint, reuse lint, codespell
- Round-trip equivalence proof above
- `gitlint` passes

## Scope

Only `.github/workflows/testing.yaml` changes. Note that `if: always()` on the step is preserved, so the summary still runs when earlier steps fail.
